### PR TITLE
refactor: Simplify unread badge logic and enhance `warning_count` upd…

### DIFF
--- a/src/main/java/com/ueadmission/chat/ChatController.java
+++ b/src/main/java/com/ueadmission/chat/ChatController.java
@@ -939,13 +939,8 @@ public class ChatController {
                 timeTooltip.setStyle("-fx-font-size: 12px;");
                 timeLabel.setTooltip(timeTooltip);
 
-                // Show unread badge if needed
-                if (user.getUnreadCount() > 0) {
-                    unreadBadge.setText(String.valueOf(Math.min(user.getUnreadCount(), 99))); // Cap at 99
-                    unreadBadgePane.setVisible(true);
-                } else {
-                    unreadBadgePane.setVisible(false);
-                }
+                // Hide unread badge as per requirement
+                unreadBadgePane.setVisible(false);
 
                 setGraphic(container);
             }

--- a/src/main/resources/database/update_exam_sessions.sql
+++ b/src/main/resources/database/update_exam_sessions.sql
@@ -3,9 +3,40 @@
 -- Use the database
 USE uiu_admission_db;
 
--- Add warning field to exam_sessions table
-ALTER TABLE exam_sessions
-ADD COLUMN warning_count INT NOT NULL DEFAULT 0;
+-- Add warning field to exam_sessions table only if it doesn't exist
+SET @columnExists = (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = 'uiu_admission_db'
+    AND table_name = 'exam_sessions'
+    AND column_name = 'warning_count'
+);
 
--- Create index for faster queries on warning_count
-CREATE INDEX idx_exam_sessions_warning_count ON exam_sessions(warning_count);
+SET @sqlStatement = IF(
+    @columnExists = 0,
+    'ALTER TABLE exam_sessions ADD COLUMN warning_count INT NOT NULL DEFAULT 0',
+    'SELECT "Column warning_count already exists in exam_sessions table"'
+);
+
+PREPARE stmt FROM @sqlStatement;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Create index for faster queries on warning_count if it doesn't exist
+SET @indexExists = (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = 'uiu_admission_db'
+    AND table_name = 'exam_sessions'
+    AND index_name = 'idx_exam_sessions_warning_count'
+);
+
+SET @sqlStatement = IF(
+    @indexExists = 0,
+    'CREATE INDEX idx_exam_sessions_warning_count ON exam_sessions(warning_count)',
+    'SELECT "Index idx_exam_sessions_warning_count already exists on exam_sessions table"'
+);
+
+PREPARE stmt FROM @sqlStatement;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
…ates

- Removed conditional logic for showing unread badge in `ChatController`, defaulting to always hidden.
- Updated `update_exam_sessions.sql` to add `warning_count` column and index only if they don't already exist, ensuring idempotency.